### PR TITLE
fix: extend kubeVersion upper bound to 1.35

### DIFF
--- a/Helm/trident/Chart.yaml
+++ b/Helm/trident/Chart.yaml
@@ -3,5 +3,5 @@ name: trident
 description: A Helm chart for deploying Trident CSI Plugin using Trident Operator
 type: application
 version: 2.0.0
-kubeVersion: ">= 1.24.0 <= 1.32"
+kubeVersion: ">= 1.24.0 <= 1.35"
 appVersion: 1.6.0

--- a/Helm/trident/Chart.yaml
+++ b/Helm/trident/Chart.yaml
@@ -3,5 +3,5 @@ name: trident
 description: A Helm chart for deploying Trident CSI Plugin using Trident Operator
 type: application
 version: 2.0.0
-kubeVersion: ">= 1.24.0 <= 1.35"
+kubeVersion: ">= 1.24.0 < 1.36"
 appVersion: 1.6.0


### PR DESCRIPTION
## Problem

The Helm chart's `kubeVersion` field is set to `>= 1.24.0 <= 1.32`, which causes `helm diff` (and `helm upgrade`) to fail with an incompatibility error on Kubernetes v1.33+:

```
Error: chart requires kubeVersion: >= 1.24.0 <= 1.32 which is incompatible with Kubernetes v1.35.1
```

The v1.6.0 release notes state support for Kubernetes v1.35, making this an oversight in the chart metadata.

## Fix

Update `kubeVersion` in `Helm/trident/Chart.yaml` to `>= 1.24.0 <= 1.35` to match the claimed Kubernetes compatibility.