### PR TITLE
Helm: bump Chart.yaml kubeVersion to <= 1.35

### DIFF
--- a/Helm/trident/Chart.yaml
+++ b/Helm/trident/Chart.yaml
@@ -3,5 +3,5 @@ name: trident
 description: A Helm chart for deploying Trident CSI Plugin using Trident Operator
 type: application
 version: 2.0.0
-kubeVersion: ">= 1.24.0 <= 1.32"
+kubeVersion: ">= 1.24.0 <= 1.35"
 appVersion: 1.6.0


### PR DESCRIPTION
The README's compatibility table for v1.6.0 states the driver supports
Kubernetes v1.24 to v1.35:

| Driver Version | Supported Kubernetes Versions |
|----------------|-------------------------------|
| v1.6.0         | v1.24 to v1.35                |

But `Helm/trident/Chart.yaml` still has the older constraint
`kubeVersion: ">= 1.24.0 <= 1.32"`, which causes:

```
Error: failed to fetch ... : 404 Not Found
```
…or, when installing from a local clone:
```
Error: chart requires kubeVersion: >= 1.24.0 <= 1.32 which is incompatible with Kubernetes v1.34.3
```

Validated locally on:
- Kubernetes 1.34.3 (Talos 1.11.6)
- TridentOrchestrator + trident-controller deploy clean
- TridentBackendConfig binds successfully against both QTS 5.2 and QuTS hero h6.0.0
- LUN provisioning + iSCSI target creation succeeds on QTS 5.2

This PR aligns the chart constraint with the documented support matrix.